### PR TITLE
Run bundle install after version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,11 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/stekke
 ## Publishing
 
 ```bash
-# Bump the gem version
-# See https://github.com/svenfuchs/gem-release#gem-bump
-gem bump --version [major|minor|patch]
-
-# Release the gem to rubygems.org
-# See https://github.com/svenfuchs/gem-release#gem-release
-gem release
-
-# Push the commit and tag to git
-git push
-git push --tags
+# - bumps the gem version to the next major, minor or patch version.
+# - creates commit for the version bump
+# - tags the commit
+# - pushes the commit and tag
+# - publishes the gem to Rubygems
+bin/release [major|minor|patch]
+# See also https://github.com/svenfuchs/gem-release#gem-bump
 ```

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+version="$1"
+bumped_version=$(gem bump --pretend --no-commit | awk '{ print $4 }' | tr -d '[:space:]')
+gem bump --version "$bumped_version"
+bundle install
+gem bump --version "$bumped_version" --tag --push --release


### PR DESCRIPTION
Updating the version needs a `bundle install` to update `Gemfile.lock`. `bin/release` inserts a `bundle install` between bumping the version and comitting/tagging/pushing/releasing.

As suggested by https://github.com/svenfuchs/gem-release/issues/93