### PR TITLE
Use Zaptec signed meter reading

### DIFF
--- a/lib/zaptec/meter_reading.rb
+++ b/lib/zaptec/meter_reading.rb
@@ -1,10 +1,46 @@
 module Zaptec
   class MeterReading
+    GOOD = "G".freeze
+    KWH = "kWh".freeze
+    READINGS = "RD".freeze
+    STATUS = "ST".freeze
+    TIMESTAMP = "TM".freeze
+    UNIT = "RU".freeze
+    VALUE = "RV".freeze
+    WH = "Wh".freeze
+
+    # https://github.com/SAFE-eV/OCMF-Open-Charge-Metering-Format/blob/master/OCMF-de.md#json-basiertes-ocmf-format
     attr_reader :reading_kwh, :timestamp
 
     def initialize(reading_kwh:, timestamp:)
       @reading_kwh = reading_kwh
       @timestamp = timestamp
+    end
+
+    class << self
+      def parse(ocmf_meter_reading)
+        _prefix, json_payload, _signature = ocmf_meter_reading.split("|")
+
+        data = JSON.parse(json_payload)
+
+        meter_reading = data.fetch(READINGS).detect do |reading|
+          reading.fetch(STATUS) == GOOD && reading[UNIT].in?([WH, KWH])
+        end
+
+        return if meter_reading.blank?
+
+        timestamp = Time.zone.parse(meter_reading.fetch(TIMESTAMP).split.first)
+
+        kwh_magnitude =
+          case meter_reading.fetch(UNIT)
+          when KWH then 1
+          when WH then 1000.0
+          end
+
+        reading_kwh = meter_reading.fetch(VALUE) / kwh_magnitude
+
+        new(reading_kwh:, timestamp:)
+      end
     end
   end
 end

--- a/lib/zaptec/state.rb
+++ b/lib/zaptec/state.rb
@@ -22,9 +22,7 @@ module Zaptec
     def online? = @data.fetch(:IsOnline).to_i.positive?
 
     def meter_reading
-      return unless charger_operation_mode == CONNECTED_CHARGING
-
-      @meter_reading ||= MeterReading.new(reading_kwh: total_charge_power, timestamp: Time.zone.now)
+      @meter_reading ||= MeterReading.parse(@data.fetch(:SignedMeterValue))
     end
 
     private

--- a/spec/zaptec/client_spec.rb
+++ b/spec/zaptec/client_spec.rb
@@ -230,44 +230,9 @@ RSpec.describe Zaptec::Client do
 
       expect(state.meter_reading)
         .to have_attributes(
-          reading_kwh: 2.83012,
-          timestamp: Time.zone.now,
+          reading_kwh: 24.368,
+          timestamp: Time.zone.parse("2022-09-28T14:00:00"),
         )
-    end
-
-    # As soon as the ChargerOperationMode changes from Connected_Charging to Connected_Finished
-    # TotalChargePower is reset to 0 and thus not usable for meter readings.
-    it "omits the meter reading when the charger finished charging (Connected_Finished)" do
-      WebMock::API
-        .stub_request(:get, "https://api.zaptec.com/api/chargers/123/state")
-        .to_return(
-          body: charger_state_example(charger_operation_mode: :Connected_Finished).to_json,
-          headers: { "Content-Type": "application/json" },
-        )
-
-      token_cache = build_token_cache("T123")
-      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
-      device_type_apollo = 4
-      state = client.state("123", device_type_apollo)
-
-      expect(state.meter_reading).to be_nil
-    end
-
-    # We assume TotalChargePower is not yet populated when ChargerOperationMode is Connected_Requesting
-    it "omits the meter reading when the charger prepares for charging (Connected_Requesting)" do
-      WebMock::API
-        .stub_request(:get, "https://api.zaptec.com/api/chargers/123/state")
-        .to_return(
-          body: charger_state_example(charger_operation_mode: :Connected_Requesting).to_json,
-          headers: { "Content-Type": "application/json" },
-        )
-
-      token_cache = build_token_cache("T123")
-      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
-      device_type_apollo = 4
-      state = client.state("123", device_type_apollo)
-
-      expect(state.meter_reading).to be_nil
     end
 
     it "raises a Forbidden error when we have no access to the charger (anymore)" do

--- a/spec/zaptec/meter_reading_spec.rb
+++ b/spec/zaptec/meter_reading_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe Zaptec::MeterReading do
+  describe "::parse" do
+    it "correctly parses a OCMF meter reading" do
+      meter_reading = Zaptec::MeterReading.parse(example_meter_reading)
+
+      expect(meter_reading)
+        .to have_attributes(
+          reading_kwh: 2935.6,
+          timestamp: Time.find_zone!("UTC").local(2018, 7, 24, 11, 22, 4),
+        )
+    end
+
+    it "support Wh readings" do
+      meter_reading = Zaptec::MeterReading.parse(example_meter_reading(unit: "Wh", value: 2935.6 * 1000))
+
+      expect(meter_reading).to have_attributes(reading_kwh: 2935.6)
+    end
+  end
+
+  def example_meter_reading(unit: "kWh", value: 2935.6)
+    <<~OCMF
+      OCMF|{
+          "FV": "1.0",
+          "GI": "ABL SBC-301",
+          "GS": "808829900001",
+          "GV": "1.4p3",
+          "PG": "T12345",
+          "MV": "Phoenix Contact",
+          "MM": "EEM-350-D-MCB",
+          "MS": "BQ27400330016",
+          "MF": "1.0",
+          "IS": true,
+          "IL": "VERIFIED",
+          "IF": [
+              "RFID_PLAIN",
+              "OCPP_RS_TLS"
+          ],
+          "IT": "ISO14443",
+          "ID": "1F2D3A4F5506C7",
+          "RD": [
+              {
+                  "TM": "2018-07-24T13:22:04,000+0200 S",
+                  "TX": "B",
+                  "RV": #{value},
+                  "RI": "1-b:1.8.0",
+                  "RU": "#{unit}",
+                  "RT": "AC",
+                  "EF": "",
+                  "ST": "G"
+              }
+          ]
+      }|{
+      "SD":  "887FABF407AC82782EEFFF2220C2F856AEB0BC22364BBCC6B55761911ED651D1A922BADA88818C9671AFEE7094D7F536"
+      }
+    OCMF
+  end
+end


### PR DESCRIPTION
total_charge_power expresses power, not energy. The only easy way to get meter readings is by utilizing the signed_meter_value.

Resolves https://github.com/stekker/backlog/issues/639