### PR TITLE
Bump rack 3.2.5 → 3.2.6 (security)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     prism (1.9.0)
     public_suffix (5.0.5)
     racc (1.7.3)
-    rack (3.2.5)
+    rack (3.2.6)
     rainbow (3.1.1)
     rake (13.2.0)
     regexp_parser (2.9.0)


### PR DESCRIPTION
Lost 13 Dependabot alerts (allemaal rack CVEs).

Patch update, geen breaking changes verwacht.