### PR TITLE
Expose final_stop_active? for diagnostic sampling

### DIFF
--- a/lib/zaptec/state.rb
+++ b/lib/zaptec/state.rb
@@ -24,6 +24,8 @@ module Zaptec
 
     def paused? = charger_operation_mode == CONNECTED_FINISHED && final_stop_active?
 
+    def final_stop_active? = @data.fetch(:FinalStopActive).to_i == 1
+
     def online? = @data.fetch(:IsOnline).to_i.positive?
 
     def session_identifier
@@ -38,8 +40,6 @@ module Zaptec
     end
 
     private
-
-    def final_stop_active? = @data.fetch(:FinalStopActive).to_i == 1
 
     def charger_operation_mode
       Constants.charger_operation_mode_to_name(@data.fetch(:ChargerOperationMode).to_i)

--- a/spec/zaptec/state_spec.rb
+++ b/spec/zaptec/state_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Zaptec::State do
+  describe "#final_stop_active?" do
+    it "is true when FinalStopActive is 1" do
+      state = Zaptec::State.new(FinalStopActive: "1")
+
+      expect(state).to be_final_stop_active
+    end
+
+    it "is false when FinalStopActive is 0" do
+      state = Zaptec::State.new(FinalStopActive: "0")
+
+      expect(state).not_to be_final_stop_active
+    end
+  end
+end


### PR DESCRIPTION
Maakt `Zaptec::State#final_stop_active?` publiek zodat clients deze waarde los kunnen uitlezen, naast `paused?`.

Achtergrond: bij sessie [1098126](https://stekker.app/orgs/sessions/1098126) bleef de charger in `Connected_Requesting` hangen zonder vermogen. We vermoeden dat `FinalStopActive` daarbij nog op 1 stond (wat een uitgebreide `paused?`-definitie rechtvaardigt), maar kunnen dat nu niet bevestigen omdat we die vlag niet apart vastleggen. Door `final_stop_active?` publiek te maken kan StekkerWeb de waarde meesamplen in `charging_connector_states`.

Geen gedragswijziging — `paused?` blijft ongewijzigd.

/cc @martijnversluis