### PR TITLE
Bump jwt to 3.2.0 and faraday to 2.14.2 for security advisories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem "byebug"
 gem "gem-release", "~> 2.2"
-gem "jwt", "~> 2.6"
+gem "jwt", "~> 3.2"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,18 +37,18 @@ GEM
       rexml
     diff-lcs (1.5.1)
     drb (2.2.3)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     gem-release (2.2.2)
     hashdiff (1.1.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.2)
-    jwt (2.8.1)
+    json (2.19.5)
+    jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.3)
     logger (1.7.0)
@@ -135,7 +135,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   gem-release (~> 2.2)
-  jwt (~> 2.6)
+  jwt (~> 3.2)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.7)


### PR DESCRIPTION
Adresseert de open Dependabot alerts:

- **jwt < 3.2.0** (high) — empty-key HMAC bypass (cross-language sibling van CVE-2026-44351).
- **faraday <= 2.14.1** (low) — incomplete fix voor host-scoping bypass via protocol-relative URI's (GHSA-33mh-2634-fwr2).

De `~> 2.6` pin op jwt is opgerekt naar `~> 3.2`. JWT wordt in deze gem niet actief gebruikt (alleen als dev dependency aanwezig).

Tests groen (35 examples).