### PR TITLE
Treat missing SignedMeterValue observation as no reading

### DIFF
--- a/lib/zaptec/state.rb
+++ b/lib/zaptec/state.rb
@@ -36,7 +36,10 @@ module Zaptec
     def operation_mode = charger_operation_mode
 
     def meter_reading
-      @meter_reading ||= MeterReading.parse(@data.fetch(:SignedMeterValue))
+      signed_meter_value = @data[:SignedMeterValue]
+      return if signed_meter_value.blank?
+
+      @meter_reading ||= MeterReading.parse(signed_meter_value)
     end
 
     private

--- a/spec/zaptec/state_spec.rb
+++ b/spec/zaptec/state_spec.rb
@@ -18,4 +18,34 @@ RSpec.describe Zaptec::State do
       expect(state).not_to be_final_stop_active
     end
   end
+
+  describe "#meter_reading" do
+    it "parses the signed meter value when present" do
+      state = Zaptec::State.new(SignedMeterValue: example_meter_reading)
+
+      expect(state.meter_reading).to have_attributes(reading_kwh: 2935.6)
+    end
+
+    it "is nil when the SignedMeterValue observation is missing from the API response" do
+      state = Zaptec::State.new({})
+
+      expect(state.meter_reading).to be_nil
+    end
+  end
+
+  def example_meter_reading
+    <<~OCMF
+      OCMF|{
+          "FV": "1.0",
+          "RD": [
+              {
+                  "TM": "2018-07-24T13:22:04,000+0200 S",
+                  "RV": 2935.6,
+                  "RU": "kWh",
+                  "ST": "G"
+              }
+          ]
+      }|{"SD":"abc"}
+    OCMF
+  end
 end


### PR DESCRIPTION
Voorkomt `KeyError: key not found: :SignedMeterValue` wanneer Zaptec's `/api/chargers/{id}/state` endpoint geen `SignedMeterValue` observatie teruggeeft. `Zaptec::State#meter_reading` retourneert nu `nil` in plaats van te crashen, wat aansluit op de callers in StekkerWeb die al een `return if meter_reading.nil?` guard hebben.

## Root cause

`Zaptec::State#meter_reading` (`lib/zaptec/state.rb:39`) gebruikt `@data.fetch(:SignedMeterValue)`. Het Zaptec state endpoint retourneert observaties spaars: alleen de StateIds die een charger ooit heeft geëmit. Een charger die nog nooit een OCMF signed meter value heeft geproduceerd (sessie net begonnen, niet-MID-certified hardware) heeft simpelweg geen row 554 in de response. De callers in StekkerWeb (`ChargePointRefreshJob#create_meter_reading` regel 107-108 en `#create_start_meter_reading` regel 124-125) doen vervolgens `return if meter_reading.nil?` — maar zien die `nil` nooit omdat `fetch` eerder al KeyError raised.

## Waarom-keten

1. Waarom crasht `ChargePointRefreshJob#create_start_meter_reading`? → `charge_point.meter_reading` raised `KeyError: key not found: :SignedMeterValue`.
2. Waarom raised die? → `Zaptec::State#meter_reading` doet `@data.fetch(:SignedMeterValue)` en de hash bevat die key niet.
3. Waarom zit `:SignedMeterValue` niet in de hash? → Zaptec's state API retourneert observaties spaars (alleen wat de charger ooit heeft geëmit). Observatie 554 verschijnt alleen op MID-certified chargers en pas vanaf de eerste signed meter event in een sessie. Op andere chargers / vroeg in een sessie is hij afwezig.
4. Waarom verwacht de gem dat hij er altijd is? → Inconsistentie. De gem heeft in dezelfde file al het nullable-patroon voor optionele observaties: `session_identifier` (regel 31-34) gebruikt `@data[:SessionIdentifier]; value.presence`, en `final_stop_active?` (regel 27, na #38) gebruikt `@data[:FinalStopActive].to_i`. `meter_reading` is per ongeluk strict gebleven.
5. Waarom is "ontbrekend" gelijk aan "geen meter reading"? → De OCMF-string wordt door `MeterReading.parse` op semantische gronden ook al nullable behandeld (`return if meter_reading.blank?` op regel 30). Geen SignedMeterValue observatie betekent: er is nog niets om te parsen. `nil` is precies de waarde die callers verwachten — `ChargePointRefreshJob` schrijft die conditie al op twee plekken.

## Waarom nu

Dit bug-patroon bestaat sinds 6440245 (2024-03-29, "Use Zaptec signed meter reading"). Eerste Sentry-event vandaag (2026-06-18) suggereert dat een net gekoppelde charger of een charger in een vroege sessie-fase voor het eerst gepolled werd zonder dat hij nog een signed meter value had geëmit. Vergelijkbare sparse-observation bug ([#38](https://github.com/stekker/zaptec/pull/38), gemerged 2026-06-03) dook ook pas op nadat een externe caller een tot dan toe onbenutte code-path raakte.

## Blast radius

Iedere Zaptec charger waarvan de state-response (nog) geen `SignedMeterValue` observatie bevat. In de praktijk: chargers in de eerste seconden/minuten van een sessie waar nog geen signed meter event is geweest, en non-MID-certified chargers die het feature niet ondersteunen. Tot dusver één event in productie, maar zonder de fix valt elke `ChargePointRefreshJob` voor zo'n charger om bij `create_meter_reading` / `create_start_meter_reading`.

## Gekozen oplossing

`Zaptec::State#meter_reading` gebruikt nu `@data[:SignedMeterValue]` met een nil short-circuit, in plaats van `fetch`. Een ontbrekende key retourneert `nil` — wat StekkerWeb's callers al verwachten. Dit volgt het bestaande nullable-patroon in dezelfde file (`session_identifier`, `final_stop_active?` na #38) en aligneert de gem met het werkelijke API-contract (sparse observation set). Adresseert why 3 (sparse API) door het contract goed te zetten, niet why 1 (de KeyError op zich).

## Alternatieven overwogen

- **Rescue KeyError in StekkerWeb's `ChargePointRefreshJob`**: symptom-fix op de verkeerde laag. De `meter_reading` API in de gem hoort nullable te zijn omdat het onderliggende data-veld dat is. Een rescue op twee call-sites in StekkerWeb verbergt het probleem; een gem-fix lost het structureel op (zoals #38 voor FinalStopActive).
- **Default `@data[:SignedMeterValue] || ""` en laten falen in `MeterReading.parse`**: legt een lege-string-conventie op die de gem nergens anders gebruikt. `nil` is de natuurlijke "geen waarde"-representatie en sluit aan op `MeterReading.parse`'s eigen nullable contract (regel 30).

## Reproductie

`spec/zaptec/state_spec.rb`: nieuwe test `"is nil when the SignedMeterValue observation is missing from the API response"` faalt vóór de fix met exact dezelfde `KeyError: key not found: :SignedMeterValue` als in Sentry 2072, en slaagt erna. Een aanvullende happy-path test borgt dat de OCMF-parsing intact blijft wanneer de observatie wél aanwezig is.

## Follow-up

Na merge: `bundle update stekker_zaptec` in `stekker/stekker` om de gem-bump uit te rollen — anders blijft Sentry 2072 doorvuren tot productie de nieuwe sha pakt.

Sentry: https://sentry2.stekker.app/organizations/sentry/issues/2072/