### PR TITLE
Cap installation-hierarchy retries by a max_wait deadline

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stekker_zaptec (1.3.0)
+    stekker_zaptec (1.4.0)
       activemodel
       activesupport
       faraday

--- a/lib/zaptec/client.rb
+++ b/lib/zaptec/client.rb
@@ -4,6 +4,7 @@ module Zaptec
     USER_ROLE = 1
     OWNER_ROLE = 2
     TOKENS_CACHE_KEY = "zaptec.auth.tokens".freeze
+    DEFAULT_HIERARCHY_RETRY_DELAYS = [2, 4].freeze
 
     attr_reader :credentials
 
@@ -72,11 +73,17 @@ module Zaptec
     end
 
     # https://api.zaptec.com/help/index.html#/Installation/get_api_installation__id__hierarchy
-    def get_installation_hierarchy(installation_id)
+    #
+    # Zaptec occasionally returns 204 while an installation is still being provisioned.
+    # `retry_delays` is the list of pauses (in seconds) between retries; its length
+    # determines the number of retries. `[]` means a single attempt, no retries.
+    def get_installation_hierarchy(installation_id, retry_delays: DEFAULT_HIERARCHY_RETRY_DELAYS)
       response = get("/api/installation/#{installation_id}/hierarchy")
 
-      if response.status == 204
-        sleep 2
+      retry_delays.each do |delay|
+        break unless response.status == 204
+
+        sleep delay
         response = get("/api/installation/#{installation_id}/hierarchy")
       end
 

--- a/lib/zaptec/client.rb
+++ b/lib/zaptec/client.rb
@@ -4,7 +4,7 @@ module Zaptec
     USER_ROLE = 1
     OWNER_ROLE = 2
     TOKENS_CACHE_KEY = "zaptec.auth.tokens".freeze
-    DEFAULT_HIERARCHY_RETRY_DELAYS = [2, 4].freeze
+    DEFAULT_HIERARCHY_MAX_WAIT = 30.seconds
 
     attr_reader :credentials
 
@@ -75,15 +75,19 @@ module Zaptec
     # https://api.zaptec.com/help/index.html#/Installation/get_api_installation__id__hierarchy
     #
     # Zaptec occasionally returns 204 while an installation is still being provisioned.
-    # `retry_delays` is the list of pauses (in seconds) between retries; its length
-    # determines the number of retries. `[]` means a single attempt, no retries.
-    def get_installation_hierarchy(installation_id, retry_delays: DEFAULT_HIERARCHY_RETRY_DELAYS)
+    # Retries with exponential backoff, doubling from 2 s, until the cumulative wait
+    # would exceed `max_wait` — at which point one final attempt runs at exactly
+    # `max_wait` seconds. `max_wait: 0` means a single attempt, no retries.
+    def get_installation_hierarchy(installation_id, max_wait: DEFAULT_HIERARCHY_MAX_WAIT)
       response = get("/api/installation/#{installation_id}/hierarchy")
+      slept = 0
+      next_attempt_at = 2
 
-      retry_delays.each do |delay|
-        break unless response.status == 204
-
-        sleep delay
+      while response.status == 204 && slept < max_wait
+        target = [next_attempt_at, max_wait].min
+        sleep(target - slept)
+        slept = target
+        next_attempt_at *= 2
         response = get("/api/installation/#{installation_id}/hierarchy")
       end
 

--- a/lib/zaptec/version.rb
+++ b/lib/zaptec/version.rb
@@ -1,3 +1,3 @@
 module Zaptec
-  VERSION = "1.3.0".freeze
+  VERSION = "1.4.0".freeze
 end

--- a/spec/zaptec/client_spec.rb
+++ b/spec/zaptec/client_spec.rb
@@ -506,7 +506,7 @@ RSpec.describe Zaptec::Client do
         )
     end
 
-    it "retries with the default backoff after 204 responses until one succeeds" do
+    it "retries with exponential backoff after 204 responses until one succeeds" do
       hierarchy_body = {
         Id: "2bbec6f9-c3ce-4edf-a72f-b1b2a663c6ba",
         Name: "Stekker test",
@@ -525,16 +525,16 @@ RSpec.describe Zaptec::Client do
       token_cache = build_token_cache("T123")
       client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
 
-      allow(client).to receive(:sleep)
+      sleeps = []
+      allow(client).to receive(:sleep) { |duration| sleeps << duration }
 
       installation_hierarchy = client.get_installation_hierarchy("I123")
 
       expect(installation_hierarchy.name).to eq("Stekker test")
-      expect(client).to have_received(:sleep).with(2).ordered
-      expect(client).to have_received(:sleep).with(4).ordered
+      expect(sleeps).to eq([2, 2])
     end
 
-    it "raises RequestFailed when every attempt returns 204 with the default retries" do
+    it "keeps retrying until the cumulative wait reaches max_wait" do
       WebMock::API
         .stub_request(:get, "https://api.zaptec.com/api/installation/I123/hierarchy")
         .to_return(status: 204, body: "", headers: {})
@@ -542,17 +542,18 @@ RSpec.describe Zaptec::Client do
       token_cache = build_token_cache("T123")
       client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
 
-      allow(client).to receive(:sleep)
+      sleeps = []
+      allow(client).to receive(:sleep) { |duration| sleeps << duration }
 
-      expect { client.get_installation_hierarchy("I123") }
+      expect { client.get_installation_hierarchy("I123", max_wait: 50) }
         .to raise_error(Zaptec::Errors::RequestFailed, "Empty response for installation hierarchy")
 
-      expect(client).to have_received(:sleep).with(2).ordered
-      expect(client).to have_received(:sleep).with(4).ordered
-      expect(WebMock).to have_requested(:get, "https://api.zaptec.com/api/installation/I123/hierarchy").times(3)
+      # Attempts happen at cumulative t = 0, 2, 4, 8, 16, 32, 50 seconds
+      expect(sleeps).to eq([2, 2, 4, 8, 16, 18])
+      expect(WebMock).to have_requested(:get, "https://api.zaptec.com/api/installation/I123/hierarchy").times(7)
     end
 
-    it "honours a caller-supplied retry_delays list" do
+    it "caps the final sleep so the last attempt happens at exactly max_wait seconds" do
       WebMock::API
         .stub_request(:get, "https://api.zaptec.com/api/installation/I123/hierarchy")
         .to_return(status: 204, body: "", headers: {})
@@ -560,19 +561,18 @@ RSpec.describe Zaptec::Client do
       token_cache = build_token_cache("T123")
       client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
 
-      allow(client).to receive(:sleep)
+      sleeps = []
+      allow(client).to receive(:sleep) { |duration| sleeps << duration }
 
-      expect { client.get_installation_hierarchy("I123", retry_delays: [1, 3, 5, 7]) }
+      expect { client.get_installation_hierarchy("I123", max_wait: 5) }
         .to raise_error(Zaptec::Errors::RequestFailed, "Empty response for installation hierarchy")
 
-      expect(client).to have_received(:sleep).with(1).ordered
-      expect(client).to have_received(:sleep).with(3).ordered
-      expect(client).to have_received(:sleep).with(5).ordered
-      expect(client).to have_received(:sleep).with(7).ordered
-      expect(WebMock).to have_requested(:get, "https://api.zaptec.com/api/installation/I123/hierarchy").times(5)
+      # Attempts at cumulative t = 0, 2, 4, 5
+      expect(sleeps).to eq([2, 2, 1])
+      expect(WebMock).to have_requested(:get, "https://api.zaptec.com/api/installation/I123/hierarchy").times(4)
     end
 
-    it "makes a single attempt with no retries when retry_delays is empty" do
+    it "accepts an ActiveSupport::Duration for max_wait" do
       WebMock::API
         .stub_request(:get, "https://api.zaptec.com/api/installation/I123/hierarchy")
         .to_return(status: 204, body: "", headers: {})
@@ -580,12 +580,30 @@ RSpec.describe Zaptec::Client do
       token_cache = build_token_cache("T123")
       client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
 
-      allow(client).to receive(:sleep)
+      sleeps = []
+      allow(client).to receive(:sleep) { |duration| sleeps << duration }
 
-      expect { client.get_installation_hierarchy("I123", retry_delays: []) }
+      expect { client.get_installation_hierarchy("I123", max_wait: 5.seconds) }
         .to raise_error(Zaptec::Errors::RequestFailed, "Empty response for installation hierarchy")
 
-      expect(client).not_to have_received(:sleep)
+      expect(sleeps).to eq([2, 2, 1])
+    end
+
+    it "makes a single attempt with no retries when max_wait is zero" do
+      WebMock::API
+        .stub_request(:get, "https://api.zaptec.com/api/installation/I123/hierarchy")
+        .to_return(status: 204, body: "", headers: {})
+
+      token_cache = build_token_cache("T123")
+      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
+
+      sleeps = []
+      allow(client).to receive(:sleep) { |duration| sleeps << duration }
+
+      expect { client.get_installation_hierarchy("I123", max_wait: 0) }
+        .to raise_error(Zaptec::Errors::RequestFailed, "Empty response for installation hierarchy")
+
+      expect(sleeps).to be_empty
       expect(WebMock).to have_requested(:get, "https://api.zaptec.com/api/installation/I123/hierarchy").once
     end
   end

--- a/spec/zaptec/client_spec.rb
+++ b/spec/zaptec/client_spec.rb
@@ -506,7 +506,7 @@ RSpec.describe Zaptec::Client do
         )
     end
 
-    it "retries once after a 204 response" do
+    it "retries with the default backoff after 204 responses until one succeeds" do
       hierarchy_body = {
         Id: "2bbec6f9-c3ce-4edf-a72f-b1b2a663c6ba",
         Name: "Stekker test",
@@ -517,6 +517,7 @@ RSpec.describe Zaptec::Client do
       WebMock::API
         .stub_request(:get, "https://api.zaptec.com/api/installation/I123/hierarchy")
         .to_return(
+          { status: 204, body: "", headers: {} },
           { status: 204, body: "", headers: {} },
           { status: 200, body: hierarchy_body, headers: { "Content-Type": "application/json" } },
         )
@@ -529,10 +530,11 @@ RSpec.describe Zaptec::Client do
       installation_hierarchy = client.get_installation_hierarchy("I123")
 
       expect(installation_hierarchy.name).to eq("Stekker test")
-      expect(client).to have_received(:sleep).with(2)
+      expect(client).to have_received(:sleep).with(2).ordered
+      expect(client).to have_received(:sleep).with(4).ordered
     end
 
-    it "raises RequestFailed after two consecutive 204 responses" do
+    it "raises RequestFailed when every attempt returns 204 with the default retries" do
       WebMock::API
         .stub_request(:get, "https://api.zaptec.com/api/installation/I123/hierarchy")
         .to_return(status: 204, body: "", headers: {})
@@ -544,6 +546,47 @@ RSpec.describe Zaptec::Client do
 
       expect { client.get_installation_hierarchy("I123") }
         .to raise_error(Zaptec::Errors::RequestFailed, "Empty response for installation hierarchy")
+
+      expect(client).to have_received(:sleep).with(2).ordered
+      expect(client).to have_received(:sleep).with(4).ordered
+      expect(WebMock).to have_requested(:get, "https://api.zaptec.com/api/installation/I123/hierarchy").times(3)
+    end
+
+    it "honours a caller-supplied retry_delays list" do
+      WebMock::API
+        .stub_request(:get, "https://api.zaptec.com/api/installation/I123/hierarchy")
+        .to_return(status: 204, body: "", headers: {})
+
+      token_cache = build_token_cache("T123")
+      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
+
+      allow(client).to receive(:sleep)
+
+      expect { client.get_installation_hierarchy("I123", retry_delays: [1, 3, 5, 7]) }
+        .to raise_error(Zaptec::Errors::RequestFailed, "Empty response for installation hierarchy")
+
+      expect(client).to have_received(:sleep).with(1).ordered
+      expect(client).to have_received(:sleep).with(3).ordered
+      expect(client).to have_received(:sleep).with(5).ordered
+      expect(client).to have_received(:sleep).with(7).ordered
+      expect(WebMock).to have_requested(:get, "https://api.zaptec.com/api/installation/I123/hierarchy").times(5)
+    end
+
+    it "makes a single attempt with no retries when retry_delays is empty" do
+      WebMock::API
+        .stub_request(:get, "https://api.zaptec.com/api/installation/I123/hierarchy")
+        .to_return(status: 204, body: "", headers: {})
+
+      token_cache = build_token_cache("T123")
+      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
+
+      allow(client).to receive(:sleep)
+
+      expect { client.get_installation_hierarchy("I123", retry_delays: []) }
+        .to raise_error(Zaptec::Errors::RequestFailed, "Empty response for installation hierarchy")
+
+      expect(client).not_to have_received(:sleep)
+      expect(WebMock).to have_requested(:get, "https://api.zaptec.com/api/installation/I123/hierarchy").once
     end
   end
 


### PR DESCRIPTION
De pairing-flow via `Connections::Zaptec#connect!` in StekkerWeb roept `get_installation_hierarchy` aan. Zaptec antwoordt bij een net-aangemaakte installatie soms met `204 No Content` totdat de provisioning klaar is. De client retryde nu **1×** met 2 s pauze en gaf daarna op — voor sommige installaties te vroeg.

## Achtergrond

Sentry-issue https://sentry2.stekker.app/organizations/sentry/issues/2101/ ving één gebruiker die pairing niet kon afronden. Uit de outbound logs:

- 18:01:47 → 204
- 18:01:49 → 204 (retry) → `RequestFailed` naar de user
- 18:01:55 → 200 (Zaptec is nu klaar, 6 s later)

De gebruiker klikte 4× de wizard opnieuw, gaf toen op, gooide het charge_point en de site weg en begon van nul. Na ~22 minuten was er een nieuwe site + nieuw charge_point met `connected_at` gezet. Onnodige moeite die met een langere backoff niet nodig was geweest.

## Wat er verandert

`get_installation_hierarchy` accepteert nu een `max_wait:` kwarg. Exponentiële backoff verdubbelt vanaf 2 s; zodra de cumulatieve wachttijd `max_wait` zou overschrijden, wordt de laatste sleep zo gecapt dat de laatste poging op precies `max_wait` seconden gebeurt.

```ruby
client.get_installation_hierarchy(id)                       # default 30.seconds
client.get_installation_hierarchy(id, max_wait: 50.seconds) # pogingen op t=0,2,4,8,16,32,50
client.get_installation_hierarchy(id, max_wait: 5.seconds)  # pogingen op t=0,2,4,5
client.get_installation_hierarchy(id, max_wait: 0)          # één poging, geen retries
```

Een `ActiveSupport::Duration` (zoals `30.seconds`) of een integer aantal seconden zijn beide geldig.

## Default

`DEFAULT_HIERARCHY_MAX_WAIT = 30.seconds` — pogingen op cumulatief t=0, 2, 4, 8, 16, 30 (6 pogingen totaal). Dat vangt de meeste provisioning-vertragingen op zonder de user langer dan een halve minuut op een spinner te laten wachten.

Consumenten die per aanroep willen tunen: batchjobs (bv. `refresh_grants_for` in StekkerWeb) kunnen `max_wait: 0` doorgeven zodat een enkele 204 gewoon wordt overgeslagen; user-facing pairing zou eventueel juist `max_wait: 60.seconds` kunnen zetten.

## Test-strategie

- Bestaande happy-path spec ongewijzigd.
- Retry-happy-path (2× 204 → 200) met assertion op de exacte sleep-sequence.
- `max_wait: 50` all-204 loopt tot deadline (pogingen op t=0,2,4,8,16,32,50, dus sleeps 2,2,4,8,16,18, WebMock times(7)).
- Cap-test met `max_wait: 5` (pogingen op t=0,2,4,5, dus sleeps 2,2,1).
- `ActiveSupport::Duration` (5.seconds) werkt identiek aan integer 5.
- `max_wait: 0` doet één poging zonder `sleep`.

Version bump naar 1.4.0 (nieuwe kwarg, backwards-compatible via default).