### PR TITLE
Fetch chargers across all pages and one charger by id

### DIFF
--- a/lib/zaptec/client.rb
+++ b/lib/zaptec/client.rb
@@ -79,6 +79,12 @@ module Zaptec
       chargers
     end
 
+    # https://docs.zaptec.com/reference/api_chargers_id_get
+    def charger(charger_id)
+      get("/api/chargers/#{charger_id}")
+        .then { |response| Charger.new(response.body) }
+    end
+
     # https://api.zaptec.com/help/index.html#/Installation/get_api_installation__id_
     def get_installation(installation_id)
       get("/api/installation/#{installation_id}")

--- a/lib/zaptec/client.rb
+++ b/lib/zaptec/client.rb
@@ -3,6 +3,7 @@ module Zaptec
     BASE_URL = "https://api.zaptec.com".freeze
     USER_ROLE = 1
     OWNER_ROLE = 2
+    CHARGERS_PAGE_SIZE = 100
     TOKENS_CACHE_KEY = "zaptec.auth.tokens".freeze
     DEFAULT_HIERARCHY_MAX_WAIT = 30.seconds
 
@@ -60,10 +61,22 @@ module Zaptec
 
     # https://api.zaptec.com/help/index.html#/Charger/get_api_chargers
     def chargers
-      get("/api/chargers", { Roles: USER_ROLE | OWNER_ROLE })
-        .body
-        .fetch("Data")
-        .map { |data| Charger.new(data) }
+      page_index = 0
+      chargers = []
+
+      loop do
+        body = get(
+          "/api/chargers",
+          { Roles: USER_ROLE | OWNER_ROLE, PageIndex: page_index, PageSize: CHARGERS_PAGE_SIZE },
+        ).body
+
+        chargers.concat(body.fetch("Data").map { |data| Charger.new(data) })
+        page_index += 1
+
+        break if page_index >= body.fetch("Pages", 1)
+      end
+
+      chargers
     end
 
     # https://api.zaptec.com/help/index.html#/Installation/get_api_installation__id_

--- a/spec/zaptec/client_spec.rb
+++ b/spec/zaptec/client_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Zaptec::Client do
         )
 
       WebMock::API
-        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3")
+        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3&PageIndex=0&PageSize=100")
         .with(headers: { "Authorization" => "Bearer T123" })
         .to_return(
           body: { Data: [] }.to_json,
@@ -60,7 +60,7 @@ RSpec.describe Zaptec::Client do
         )
 
       WebMock::API
-        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3")
+        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3&PageIndex=0&PageSize=100")
         .with(headers: { "Authorization" => "Bearer T789" })
         .to_return(
           body: { Data: [] }.to_json,
@@ -98,7 +98,7 @@ RSpec.describe Zaptec::Client do
         )
 
       WebMock::API
-        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3")
+        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3&PageIndex=0&PageSize=100")
         .with(headers: { "Authorization" => "Bearer T123" })
         .to_return(
           body: { Data: [] }.to_json,
@@ -165,7 +165,7 @@ RSpec.describe Zaptec::Client do
   describe "#chargers" do
     it "gets the list of chargers" do
       WebMock::API
-        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3")
+        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3&PageIndex=0&PageSize=100")
         .to_return(
           body: chargers_example.to_json,
           headers: { "Content-Type": "application/json" },
@@ -185,6 +185,28 @@ RSpec.describe Zaptec::Client do
           installation_name: "Zaptechof 1",
           installation_id: "2bbec6f9-c3ce-4edf-a72f-b1b2a663c6ba",
         )
+    end
+
+    it "walks every page of the chargers listing" do
+      first_page = chargers_example.merge(Pages: 2)
+      second_charger = chargers_example[:Data].first.merge(
+        Id: "aaa603a7-ff53-4ed8-8dd6-f79c94819458",
+        DeviceId: "GPN012345",
+        Name: "Zaptec 2",
+      )
+      second_page = { Pages: 2, Data: [second_charger] }
+
+      WebMock::API
+        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3&PageIndex=0&PageSize=100")
+        .to_return(body: first_page.to_json, headers: { "Content-Type": "application/json" })
+      WebMock::API
+        .stub_request(:get, "https://api.zaptec.com/api/chargers?Roles=3&PageIndex=1&PageSize=100")
+        .to_return(body: second_page.to_json, headers: { "Content-Type": "application/json" })
+
+      token_cache = build_token_cache("T123")
+      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
+
+      expect(client.chargers.map(&:device_id)).to eq %w[ZAP049387 GPN012345]
     end
   end
 

--- a/spec/zaptec/client_spec.rb
+++ b/spec/zaptec/client_spec.rb
@@ -187,6 +187,25 @@ RSpec.describe Zaptec::Client do
         )
     end
 
+    it "fetches a single charger by id" do
+      WebMock::API
+        .stub_request(:get, "https://api.zaptec.com/api/chargers/93d603a7-ff53-4ed8-8dd6-f79c94819458")
+        .to_return(
+          body: chargers_example[:Data].first.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      token_cache = build_token_cache("T123")
+      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
+
+      expect(client.charger("93d603a7-ff53-4ed8-8dd6-f79c94819458"))
+        .to have_attributes(
+          id: "93d603a7-ff53-4ed8-8dd6-f79c94819458",
+          device_id: "ZAP049387",
+          device_type: 4,
+        )
+    end
+
     it "walks every page of the chargers listing" do
       first_page = chargers_example.merge(Pages: 2)
       second_charger = chargers_example[:Data].first.merge(


### PR DESCRIPTION
`client.chargers` las alleen pagina 1 van het gepagineerde `GET /api/chargers`. Op het gedeelde Stekker-account (139+ chargers) was daardoor alles buiten de eerste pagina onvindbaar — in StekkerWeb bleven zo 65 ERE-laders zonder gekoppeld catalogusmodel, omdat `ResolveChargePointModelJob` hun charger simpelweg nooit in de listing zag (stille no-op, geen fouten in Sentry).

Twee wijzigingen:

- `chargers` loopt nu alle pagina's af (`PageIndex`/`PageSize=100`, tot het `Pages`-veld uit de response bereikt is).
- Nieuw: `charger(id)` via [`GET /api/chargers/{id}`](https://docs.zaptec.com/reference/api_chargers_id_get), zodat een caller die maar één lader nodig heeft (zoals de model-resolve in StekkerWeb) niet per lookup de hele account-listing hoeft te doorlopen.

Volgt op stekker/stekker#8228; de StekkerWeb-kant (resolve via `charger(id)` + gem-bump) komt in een aparte PR zodra dit gemerged is.