### PR TITLE
Patch concurrent-ruby lock and atomic-reference advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.0.1)
     byebug (11.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.0)
       bigdecimal


### PR DESCRIPTION
Bumpt `concurrent-ruby` van 1.3.6 → 1.3.7.

Dicht drie Dependabot alerts:
- [#52](https://github.com/stekker/zaptec/security/dependabot/52) — `AtomicReference#update` livelocks bij `Float::NAN` (high)
- [#53](https://github.com/stekker/zaptec/security/dependabot/53) — `ReentrantReadWriteLock` read-count overflow grants write lock without exclusivity
- [#51](https://github.com/stekker/zaptec/security/dependabot/51) — `ReadWriteLock` allows wrong-thread write release and read-release counter corruption