### PR TITLE
Fetch details for a single charging session

### DIFF
--- a/lib/stekker_zaptec.rb
+++ b/lib/stekker_zaptec.rb
@@ -16,6 +16,7 @@ require "zaptec/installation"
 require "zaptec/installation_hierarchy"
 require "zaptec/meter_reading"
 require "zaptec/null_encryptor"
+require "zaptec/session"
 require "zaptec/state"
 require "zaptec/version"
 

--- a/lib/zaptec/client.rb
+++ b/lib/zaptec/client.rb
@@ -140,6 +140,12 @@ module Zaptec
       post("/api/chargers/#{charger_id}/update", body: attributes)
     end
 
+    # https://docs.zaptec.com/reference/api_session_id_get
+    def session(id)
+      get("/api/session/#{id}")
+        .then { |response| Session.new(response.body) }
+    end
+
     # https://api.zaptec.com/help/index.html#/Session/api_sessions_archived_get
     def archived_sessions(from:, to:, installation_id: nil, charger_id: nil, page_size: nil, cursor: nil)
       if installation_id.blank? == charger_id.blank?

--- a/lib/zaptec/session.rb
+++ b/lib/zaptec/session.rb
@@ -1,0 +1,23 @@
+module Zaptec
+  class Session
+    def initialize(data)
+      @data = data.deep_symbolize_keys
+    end
+
+    def id = @data.fetch(:sessionId)
+    def energy_kwh = @data[:energy]
+    def signed_session = @data[:signedSession]
+
+    def session_start = parse_time(:sessionStart)
+    def session_end = parse_time(:sessionEnd)
+
+    private
+
+    def parse_time(key)
+      value = @data[key]
+      return if value.nil?
+
+      Time.zone.parse(value)
+    end
+  end
+end

--- a/spec/zaptec/client_spec.rb
+++ b/spec/zaptec/client_spec.rb
@@ -940,6 +940,59 @@ RSpec.describe Zaptec::Client do
     end
   end
 
+  describe "#session" do
+    it "fetches details for a single session by id" do
+      WebMock::API
+        .stub_request(:get, "https://api.zaptec.com/api/session/b1e5a5f0-1111-4c8b-9d2f-000000000001")
+        .to_return(
+          body: {
+            sessionId: "b1e5a5f0-1111-4c8b-9d2f-000000000001",
+            sessionStart: "2026-01-05T10:00:00Z",
+            sessionEnd: "2026-01-05T11:30:00Z",
+            energy: 12.34,
+            signedSession: "OCMF-signature-blob",
+          }.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      token_cache = build_token_cache("T123")
+      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
+
+      session = client.session("b1e5a5f0-1111-4c8b-9d2f-000000000001")
+
+      expect(session).to be_a(Zaptec::Session)
+      expect(session).to have_attributes(
+        id: "b1e5a5f0-1111-4c8b-9d2f-000000000001",
+        session_start: Time.zone.parse("2026-01-05T10:00:00Z"),
+        session_end: Time.zone.parse("2026-01-05T11:30:00Z"),
+        energy_kwh: 12.34,
+      )
+    end
+
+    it "leaves session_end nil while the session is still ongoing" do
+      WebMock::API
+        .stub_request(:get, "https://api.zaptec.com/api/session/b1e5a5f0-1111-4c8b-9d2f-000000000002")
+        .to_return(
+          body: {
+            sessionId: "b1e5a5f0-1111-4c8b-9d2f-000000000002",
+            sessionStart: "2026-01-05T10:00:00Z",
+            sessionEnd: nil,
+            energy: 0.0,
+            signedSession: nil,
+          }.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      token_cache = build_token_cache("T123")
+      client = Zaptec::Client.new(username: "zap", password: "tec", token_cache:)
+
+      session = client.session("b1e5a5f0-1111-4c8b-9d2f-000000000002")
+
+      expect(session.session_start).to eq Time.zone.parse("2026-01-05T10:00:00Z")
+      expect(session.session_end).to be_nil
+    end
+  end
+
   private
 
   def chargers_example

--- a/spec/zaptec/session_spec.rb
+++ b/spec/zaptec/session_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Zaptec::Session do
+  it "exposes the session fields" do
+    session = described_class.new(
+      "sessionId" => "b1e5a5f0-1111-4c8b-9d2f-000000000001",
+      "sessionStart" => "2026-01-05T10:00:00Z",
+      "sessionEnd" => "2026-01-05T11:30:00Z",
+      "energy" => 12.34,
+      "signedSession" => "OCMF-signature-blob",
+    )
+
+    expect(session).to have_attributes(
+      id: "b1e5a5f0-1111-4c8b-9d2f-000000000001",
+      session_start: Time.zone.parse("2026-01-05T10:00:00Z"),
+      session_end: Time.zone.parse("2026-01-05T11:30:00Z"),
+      energy_kwh: 12.34,
+      signed_session: "OCMF-signature-blob",
+    )
+  end
+
+  it "returns nil for session_end and signed_session when the session is still ongoing" do
+    session = described_class.new(
+      "sessionId" => "b1e5a5f0-1111-4c8b-9d2f-000000000001",
+      "sessionStart" => "2026-01-05T10:00:00Z",
+      "sessionEnd" => nil,
+      "energy" => 0.0,
+      "signedSession" => nil,
+    )
+
+    expect(session).to have_attributes(
+      session_end: nil,
+      signed_session: nil,
+    )
+  end
+end


### PR DESCRIPTION
De gem kan nu de details van een enkele laadsessie ophalen via [`GET /api/session/{id}`](https://docs.zaptec.com/reference/api_session_id_get). Onderdeel van [stekker/backlog#1996](https://github.com/stekker/backlog/issues/1996): daar willen we `session.start_at` / `end_at` in StekkerWeb vullen met de canonieke Zaptec-timestamps in plaats van `Time.current` op het moment dat wij het bericht verwerken.

## Wat er verandert

Nieuwe publieke method op de client:

```ruby
client.session(id)
# => Zaptec::Session
#      #id             => String (UUID)
#      #session_start  => ActiveSupport::TimeWithZone
#      #session_end    => ActiveSupport::TimeWithZone of nil (nil = sessie loopt nog)
#      #energy_kwh     => Float
#      #signed_session => String of nil (OCMF-signature)
```

`session_end` is nullable in de Zaptec-API — het endpoint werkt dus zowel voor lopende als afgesloten sessies. Voor lopende sessies is `signed_session` ook nog `nil`.

## Waarom een aparte `Session`-klasse

Naast de bestaande `Zaptec::ArchivedSession` (uit `/api/sessions/archived`, alleen historische lijst-items) is dit een compactere representatie voor het single-session endpoint. De schema's overlappen deels maar de responses zijn niet identiek (`SessionEndData` heeft minder velden dan het archived-session-model), dus geen shared parser.

## Naaste kanten

De caller in StekkerWeb gaat dit endpoint alleen bij session-transitions aanroepen (start / end), niet elke poll-tick — zie [stekker/backlog#1996](https://github.com/stekker/backlog/issues/1996) voor het integratie-ontwerp.